### PR TITLE
FullWriteReadTest에러 안나게 수정했습니다.

### DIFF
--- a/src/test/java/shell/FullWriteFullReadTest.java
+++ b/src/test/java/shell/FullWriteFullReadTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import shell.command.Document;
+import shell.command.WriteCommand;
+import shell.command.ReadCommand;
 
 import java.io.*;
 import java.util.*;
@@ -14,8 +17,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class FullWriteFullReadTest {
 
-    private static final int MAX_LBA = 100;
-    private static final String TEST_VALUE = "ABCDFFFF";
+    private static final int MAX_LBA = 99;
+    private static final String TEST_VALUE = "0xABCDFFFF";
 
     @Mock
     private TestShell mockTestShell;
@@ -23,6 +26,9 @@ public class FullWriteFullReadTest {
     private ByteArrayOutputStream outputStream;
     private PrintStream originalOut;
     private Map<Integer, String> testData; // 테스트 데이터 추가
+    private Document mockDocument;
+    private WriteCommand writeCommand;
+    private ReadCommand readCommand;
 
     @BeforeEach
     void setUp() {
@@ -30,11 +36,9 @@ public class FullWriteFullReadTest {
         originalOut = System.out;
         System.setOut(new PrintStream(outputStream));
 
-        // 테스트 데이터 초기화 (setUp()으로 이동)
-        testData = new HashMap<>();
-        for (int i = 0; i < MAX_LBA; i++) {
-            testData.put(i, String.format("%08X", i * 0x1000 + 0xABCD));
-        }
+        mockDocument = mock(Document.class);
+        writeCommand = new WriteCommand(mockDocument);
+        readCommand = new ReadCommand(mockDocument);
     }
 
     @AfterEach
@@ -44,69 +48,62 @@ public class FullWriteFullReadTest {
     }
 
     @Test
-    void FullWrite_수행시_writeLBA_100번_수행_여부_확인() {
-        // Arrange: Mock의 fullWrite가 실제처럼 동작하도록 설정
-        doAnswer(invocation -> {
-            String hexValue = invocation.getArgument(0);
-            // 실제 fullWrite 로직 시뮤레이션
-            for (int lba = 0; lba < MAX_LBA; lba++) {
-                mockTestShell.writeLBA(lba, hexValue);
-            }
-            return null;
-        }).when(mockTestShell).fullWrite(anyString());
-        
-        doNothing().when(mockTestShell).writeLBA(anyInt(), anyString());
+    void FullWrite_정상_테스트_확인() {
 
-        // Act
-        mockTestShell.fullWrite(TEST_VALUE);
+        String[] args = {"fullwrite", TEST_VALUE};
 
-        // Assert
-        verify(mockTestShell, times(MAX_LBA)).writeLBA(anyInt(), eq(TEST_VALUE));
+        // When
+        writeCommand.execute(args);
+
+        // Then
+        verify(mockDocument).write(0, MAX_LBA,TEST_VALUE );
+
+    }
+
+    void FullWrite_Input_value_오류_확인() {
+
+        String[] args = {"fullwrite", "ABCDFFFF"};
+
+        // When
+        writeCommand.execute(args);
+
+        // Then
+        // Then
+        String output = outputStream.toString().trim();
+        assertTrue(output.contains("INVALID COMMAND"));
+        verify(mockDocument, never()).write(0, MAX_LBA,TEST_VALUE );
     }
 
     @Test
-    void FullRead_수행시_readLBA_100번_수행_여부_확인() {
-        // Arrange: Mock의 fullRead가 실제처럼 동작하도록 설정
-        doAnswer(invocation -> {
-            // 실제 fullRead 로직 시뮤레이션
-            for (int lba = 0; lba < MAX_LBA; lba++) {
-                String value = mockTestShell.readLBA(lba);
-                System.out.println("LBA " + String.format("%02d", lba) + ": " + value);
-            }
-            return null;
-        }).when(mockTestShell).fullRead();
-        
-        when(mockTestShell.readLBA(anyInt()))
-            .thenAnswer(invocation -> {
-                int lba = invocation.getArgument(0);
-                return "0x" + testData.get(lba);
-            });
+    void FullRead_정상_테스트_확인() {
 
-        // Act
-        mockTestShell.fullRead();
+        String[] args = {"fullwrite", TEST_VALUE};
 
-        // Assert
-        verify(mockTestShell, times(MAX_LBA)).readLBA(anyInt());
-        assertOutputMatchesExpected();
+        // When
+        writeCommand.execute(args);
+
+        String[] readArgs = {"fullread"};
+
+        // When
+        readCommand.execute(readArgs);
+
+        // Then
+        verify(mockDocument).read(0, MAX_LBA );
+
     }
 
-    private void assertOutputMatchesExpected() {
-        String output = outputStream.toString();
-        String[] lines = output.split(System.lineSeparator());
+    void FullRead_파라미터_오류_확인() {
 
-        // 빈 라인 제거
-        List<String> nonEmptyLines = new ArrayList<>();
-        for (String line : lines) {
-            if (!line.trim().isEmpty()) {
-                nonEmptyLines.add(line);
-            }
-        }
+        String[] args = {"readfull"};
 
-        assertEquals(MAX_LBA, nonEmptyLines.size(), "100개의 LBA 값이 출력되어야 함");
+        // When
+        readCommand.execute(args);
 
-        for (int i = 0; i < MAX_LBA; i++) {
-            String expectedLine = "LBA " + String.format("%02d", i) + ": 0x" + testData.get(i);
-            assertEquals(expectedLine, nonEmptyLines.get(i), "LBA " + i + "의 출력 형식이 올바르지 않음");
-        }
+        // Then
+        String output = outputStream.toString().trim();
+        assertTrue(output.contains("INVALID COMMAND"));
+        verify(mockDocument, never()).read(0, MAX_LBA);
     }
+
+
 }


### PR DESCRIPTION
## 🔍 개요
<!-- 어떤 기능/수정인지 한 줄 요약해주세요 -->
- 예: VirtualSSD 예외 처리 보완 및 fullwrite 명령어 구현

---
fullReadFullWriteTest 에러나지 않도록 수정했습니다. 

## ✅ 작업 내용 체크리스트
- [ ] 기능 구현 (Command: W / R / fullwrite / fullread)
- [ ] 예외 처리 (`ERROR` 출력 통일, 대소문자 검증 등)
- [O ] 테스트 코드 작성 및 통과 (JUnit5 + Mockito)
- [ ] Gradle 빌드 및 실행 확인 (`ssd-app.jar`, `test-shell.jar`)
- [ ] 문서/README/명세서 반영

---

## 💡 상세 설명
<!-- 구현 방식, 고려한 점, 한계 등 자유롭게 기술해주세요 -->
- 예: `TestShell`에 InputReader/OutputWriter 분리하여 테스트 가능하게 개선

--- TestShell에서 fullwrite, fullread 테스트 가능하게 개선

## 🧪 테스트 결과
<!-- 테스트 수행 결과를 요약해주세요 -->
- 예: `TestShellTest` 정상 통과 (PASS)
- 예외 상황 시 `"ERROR"` 출력 확인

---
![image](https://github.com/user-attachments/assets/48d75b3e-f9ad-4298-b75f-4c2fd7faab6c)
![image](https://github.com/user-attachments/assets/48d75b3e-f9ad-4298-b75f-4c2fd7faab6c)
![image](https://github.com/user-attachments/assets/48d75b3e-f9ad-4298-b75f-4c2fd7faab6c)


## 🔁 관련 이슈
<!-- 관련된 이슈 번호 또는 작업 항목 -->
- close #10
- ref #5

---

## 📎 기타 참고 사항
<!-- 리뷰어가 참고할만한 정보 (스크린샷, 로그, 참고 링크 등) -->
